### PR TITLE
fix fetching abroad shipping methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ spec/dummy
 
 .ruby-gemset
 .ruby-version
+
+*.gem

--- a/lib/active_shipping/shipping/carriers/send_cloud.rb
+++ b/lib/active_shipping/shipping/carriers/send_cloud.rb
@@ -18,8 +18,7 @@ module ActiveMerchant
         success = true
         response = []
         sendcloud_shipping.list.each do |shipping_method|
-          if (shipping_method['countries'].any?{|c| c['iso_2'] == origin.country_code} &&
-              shipping_method['countries'].any?{|c| c['iso_2'] == destination.country_code})
+          if shipping_method['countries'].any?{|c| c['iso_2'] == destination.country_code}
             country_price = 0
             shipping_method['countries'].each {|c| country_price = c['price'] if c['iso_2'] == destination.country_code}
             response << RateEstimate.new(origin, destination, @@name,

--- a/spree_sendcloud.gemspec
+++ b/spree_sendcloud.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_sendcloud'
-  s.version     = '3.0.0.beta'
+  s.version     = '3.0.1.beta'
   s.summary     = 'Use Sendcloud shipping for your SpreeCommerce storefront'
   s.description = s.summary
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
By checking the origin country aswell as the destination country for available shipping methods, abroad shipping methods cannot be found if they do not ship to the origin. By removing the origin the rates for the destination can be found correctly